### PR TITLE
all projects in codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -87,11 +87,27 @@ jobs:
       run:
         arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/buttons_1/buttons_1.ino --warnings=all
 
+    - name: Build Lolin DHT Webserver
+      run:
+        |
+        cp $PWD/Lolin_1/dht_webserver/credentials.h.sample $PWD/Lolin_1/dht_webserver/credentials.h
+        arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/dht_webserver/dht_webserver.ino --warnings=all
+
     - name: Build Lolin shelly parser
       run:
         |
         cp $PWD/Lolin_1/shelly_parser/credentials.h.sample $PWD/Lolin_1/shelly_parser/credentials.h
         arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/shelly_parser/shelly_parser.ino --warnings=all
+
+    - name: Build Lolin state machine 1
+      run:
+        arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/state_machine_1/state_machine_1.ino --warnings=all
+
+    - name: Build Lolin window controller
+      run:
+        |
+        cp $PWD/Lolin_1/window_controller/credentials.h.sample $PWD/Lolin_1/window_controller/credentials.h
+        arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/window_controller/window_controller.ino --warnings=all
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,6 +61,9 @@ jobs:
         arduino-cli board listall
         arduino-cli core search d1_mini
         arduino-cli lib install ArduinoJson
+        arduino-cli lib install Adafruit_Unified_Sensor
+        arduino-cli lib install DHT_sensor_library
+        arduino-cli lib install LiquidCrystal
 
     - name: Static link
       run:
@@ -72,11 +75,19 @@ jobs:
           chmod +x "$i";
         done
 
-    - name: Build example 1
+    - name: Build DHT-11 read dht 1
+      run:
+        arduino-cli compile --fqbn arduino:avr:nano:cpu=atmega328 $PWD/DHT-11_1/read_dht_01/read_dht_01.ino --warnings=all
+
+    - name: Build DHT-11 read dht 2
+      run:
+        arduino-cli compile --fqbn arduino:avr:nano:cpu=atmega328 $PWD/DHT-11_1/read_dht_02/read_dht_02.ino --warnings=all
+
+    - name: Build Lolin buttons 1
       run:
         arduino-cli compile --fqbn esp8266:esp8266:d1_mini $PWD/Lolin_1/buttons_1/buttons_1.ino --warnings=all
 
-    - name: Build example 2
+    - name: Build Lolin shelly parser
       run:
         |
         cp $PWD/Lolin_1/shelly_parser/credentials.h.sample $PWD/Lolin_1/shelly_parser/credentials.h

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         arduino-cli board listall
         arduino-cli core search d1_mini
         arduino-cli lib install ArduinoJson
-        arduino-cli lib install Adafruit_Unified_Sensor
+        arduino-cli lib install Adafruit_Sensor
         arduino-cli lib install DHT_sensor_library
         arduino-cli lib install LiquidCrystal
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,8 +61,8 @@ jobs:
         arduino-cli board listall
         arduino-cli core search d1_mini
         arduino-cli lib install ArduinoJson
-        arduino-cli lib install Adafruit_Sensor
-        arduino-cli lib install DHT_sensor_library
+        arduino-cli lib install "Adafruit Unified Sensor"
+        arduino-cli lib install "DHT sensor library"
         arduino-cli lib install LiquidCrystal
 
     - name: Static link

--- a/DHT-11_1/read_dht_01/README.md
+++ b/DHT-11_1/read_dht_01/README.md
@@ -6,6 +6,10 @@ and writes it to the serial interface.
 See my blog post (in German) for
 [more information](https://blog.rolandbaer.ch/2020/03/07/temperatur-und-luftfeuchtigkeit-messen-mit-dem-arduino-nano/).
 
+Required Libraries:
+- Adafruit Unified Sensor by Adafruit (Adafruit_Unified_Sensor)
+- DHT sensor library by Adafruit (DHT_sensor_library)
+
 To run the program you should it connect like in the schema below. Take care
 of the DHT-11 or DHT-12 version you have. Mine had the connectors
 VCC / Data / GND, but there are also modules with Data / VCC / GND!

--- a/DHT-11_1/read_dht_02/README.md
+++ b/DHT-11_1/read_dht_02/README.md
@@ -7,6 +7,11 @@ the usb port of the arduino nano.
 See my blog post (in German) for
 [more information](https://blog.rolandbaer.ch/2020/03/23/temperatur-und-luftfeuchtigkeit-messen-und-anzeigen-mit-dem-arduino-nano/).
 
+Required Libraries:
+- Adafruit Unified Sensor by Adafruit (Adafruit_Unified_Sensor)
+- DHT sensor library by Adafruit (DHT_sensor_library)
+- LiquidCrystal by Arduino, Adafruit (LiquidCrystal)
+
 To run the program you should it connect like in the schema below. Take care
 of the DHT-11 or DHT-12 version you have. Mine had the connectors
 VCC / Data / GND, but there are also modules with Data / VCC / GND!

--- a/Lolin_1/dht_webserver/README.md
+++ b/Lolin_1/dht_webserver/README.md
@@ -9,6 +9,15 @@ password to your WiFi network credentials.
 See my blog post (in German) for
 [more information](https://blog.rolandbaer.ch/2020/03/30/wemos-d1-mini-als-temperatur-und-luftfeuchtigkeits-webserver/).
 
+Board:
+- LOLIN(WEMOS) D1 R2 & mini
+
+Required Libraries:
+- ESP8266WiFi
+- ESP8266 Web Server (ESP8266WebServer)
+- Adafruit Unified Sensor by Adafruit (Adafruit_Unified_Sensor)
+- DHT sensor library by Adafruit (DHT_sensor_library)
+
 To run the program you should it connect like in the schema below. Take care
 of the DHT-11 or DHT-12 version you have. Mine had the connectors
 VCC / Data / GND, but there are also modules with Data / VCC / GND!

--- a/Lolin_1/shelly_parser/README.md
+++ b/Lolin_1/shelly_parser/README.md
@@ -3,5 +3,13 @@
 This programm is a small sample to read the cover state of a shelly plus 2PM.
 It reads the state and prints it to the console.
 
+Board:
+- LOLIN(WEMOS) D1 R2 & mini
+
+Required Libraries:
+- ESP8266WiFi
+- ESP8266HTTPClient
+- ArduinoJson by Benoit Blanchon
+
 To run the program you only need a Wemos Lolin D1 mini or compatible 
 controller.

--- a/Lolin_1/state_machine_1/README.md
+++ b/Lolin_1/state_machine_1/README.md
@@ -12,6 +12,13 @@ to ease the stress on relays and motor.
 As soon as the humidity or temperature is under a defined level the window is
 closed automatically.
 
+Board:
+- LOLIN(WEMOS) D1 R2 & mini
+
+Required Libraries:
+- Adafruit Unified Sensor by Adafruit (Adafruit_Unified_Sensor)
+- DHT sensor library by Adafruit (DHT_sensor_library)
+
 To run the program you should it connect like in the schema below. Take care
 of the DHT-11 or DHT-12 version you have. Mine had the connectors
 VCC / Data / GND, but there are also modules with Data / VCC / GND!

--- a/Lolin_1/window_controller/README.md
+++ b/Lolin_1/window_controller/README.md
@@ -19,6 +19,15 @@ manual mode where the window will not be closed automatically.
 Copy `credentials.h.sample` to `credentials.h` and change the ssid and
 password to your WiFi network credentials.
 
+Board:
+- LOLIN(WEMOS) D1 R2 & mini
+
+Required Libraries:
+- ESP8266WiFi
+- ESP8266 Web Server (ESP8266WebServer)
+- Adafruit Unified Sensor by Adafruit (Adafruit_Unified_Sensor)
+- DHT sensor library by Adafruit (DHT_sensor_library)
+
 To run the program you should it connect like in the schema below. Take care
 of the DHT-11 or DHT-12 version you have. Mine had the connectors
 VCC / Data / GND, but there are also modules with Data / VCC / GND!

--- a/Lolin_1/window_controller/window_controller.ino
+++ b/Lolin_1/window_controller/window_controller.ino
@@ -18,7 +18,7 @@ const uint8_t PIN_BUTTON_CLOSE = D7;
 const uint8_t PIN_RELAY_OPEN = D1;
 const uint8_t PIN_RELAY_CLOSE = D2;
 
-const uint8_t PIN_MANUAL_MODE = BUILTIN_LED;
+const uint8_t PIN_MANUAL_MODE = LED_BUILTIN;
 
 const uint8_t DHTPIN = D5;         // pin where the sensor is connected to
 const uint8_t DHTTYPE = DHT11;     // define the type of sensor (DHT11 or DHT22)
@@ -51,6 +51,8 @@ String printState(State _state) {
     case State::Closed:
       return "Closed";
   }
+
+  return "Unknown";
 }
 
 // create instance of DHT                          


### PR DESCRIPTION
adding all projects to the codeql analyzer
- read_dht_1
- read_dht_2
- dht_webserver
- state_machine_1
- window_controller

Fixed 2 warnings in window_controller

All README.md include now information about the supported/tested board and the used libraries.

fixes #2 